### PR TITLE
Fix shifted sponsors section & remove hello world

### DIFF
--- a/css/creative2.css
+++ b/css/creative2.css
@@ -413,3 +413,7 @@ img::-moz-selection {
 body {
   webkit-tap-highlight-color: #A5A5A5;
 }
+
+.center-sponsors {
+    text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -181,10 +181,12 @@
     <section id="sponsors">
         <div class="container">
             <div class="row">
-                <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <h2 class="section-heading">Sponsors</h2>
-                    <hr class="primary">
-                    <p>If you would like to sponsor HackTrin III, please email us at <a href="mailto:grace.zhang16@trinityschoolnyc.org" target="_top">grace.zhang16@trinityschoolnyc.org</a></p>
+                <div class="text-center">
+                    <div class='center-sponsors'>
+                        <h2 class="section-heading">Sponsors</h2>
+                        <hr class="primary">
+                        <p>If you would like to sponsor HackTrin III, please email us at <a href="mailto:grace.zhang16@trinityschoolnyc.org" target="_top">grace.zhang16@trinityschoolnyc.org</a></p>
+                    </div>
                     <div class="container">
 		                <div class="row">
 		                    <div class="col-lg-3 col-md-3 col-xs-6 thumb">
@@ -208,7 +210,7 @@
 		                        </a>
 		                    </div>
 		                </div>
-                        
+
                         <div class="row">
                             <div class="col-lg-3 col-md-3 col-xs-6 thumb">
                                 <a class="thumbnail" href="https://selfie.com/">

--- a/index2.html
+++ b/index2.html
@@ -1,1 +1,0 @@
-Hello, World!


### PR DESCRIPTION
Current (shifted):
![image](https://cloud.githubusercontent.com/assets/1058150/12400373/97132b10-bded-11e5-9ace-4b1e844988b9.png)

Patch (Unshifted):
![image](https://cloud.githubusercontent.com/assets/1058150/12400383/ad6d84b4-bded-11e5-95ea-45133e7891c9.png)

This pull request also removes a `hello world` file in the root of the website.
